### PR TITLE
Don't abuse PRNG -> fix identifier generation when building on Windows

### DIFF
--- a/Cryptor/Cryptor.go
+++ b/Cryptor/Cryptor.go
@@ -24,6 +24,10 @@ var (
 	ErrInvalidPKCS7Padding = errors.New("invalid padding on input")
 )
 
+func init() {
+	crand.Seed(time.Now().UnixNano())
+}
+
 func Pkcs7Pad(b []byte, blocksize int) ([]byte, error) {
 	if blocksize <= 0 {
 		return nil, ErrInvalidBlockSize
@@ -58,7 +62,6 @@ func RandStringBytes(n int) string {
 
 func VarNumberLength(min, max int) string {
 	var r string
-	crand.Seed(time.Now().UnixNano())
 	num := crand.Intn(max-min) + min
 	n := num
 	r = RandStringBytes(n)
@@ -72,7 +75,6 @@ func printHexOutput(input ...[]byte) {
 }
 
 func GenerateNumer(min, max int) int {
-	crand.Seed(time.Now().UnixNano())
 	num := crand.Intn(max-min) + min
 	n := num
 	return n


### PR DESCRIPTION
Pseudorandom number generators need to be initialized only once.

Using the system time for this is Generally Fine, but re-initializing
the PRNG in a tight loop every time a random number is needed
significantly raises the odds that the same number sequence (or even
the same number) is returned every time.

Chances for this to happen on Windows are apparently much higher than
on Linux. Not sure why this is the case, my best guess is that the
clock used for Go's `time.Now()´ runs with coarser granularity.