### PR TITLE
update installation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ go build ZipExec.go
   
  or 
   
-```go get github.com/Tylous/ZipExec  ```
+```
+go install github.com/Tylous/ZipExec@latest
+```
 
 ## Help
 ```


### PR DESCRIPTION
Starting in Go 1.17, installing executables with go get is deprecated. go install may be used instead.
ref: https://golang.org/doc/go-get-install-deprecation